### PR TITLE
Updating to Ansible 2.10 and several improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Updated to Ansible v2.10 (use of collections) and several improvements:
 * The variable `pve_hostname` is now available to use custom hostnames and provide more versatility than the old form inferred from inventory.
+* To prevent unwanted impacts and security issues on a cluster in production, the cluster configuration is no longer configured by default.
 * Now, using `modification_time` and `access_time` parameters in the `ansible.builtin.file` module, the complete idempotency of the role is duly represented in the tasks results.
 * Proxmoxer is not required for the tasks of this role. The tasks that ensured that this false dependency was installed were removed.
 * Full implementation of `pve_*` namespace usage, consistent with other Proxmox roles.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,19 @@
 # Change Log of [`udelarinterior.firewall_proxmox` role](https://github.com/UdelaRInterior/ansible-role-firewall-proxmox)
 
+## [v3.0.0](https://github.com/UdelaRInterior/ansible-role-firewall-proxmox/tree/v3.0.0)
+
+Updated to Ansible v2.10 (use of collections) and several improvements:
+* The variable `pve_hostname` is now available to use custom hostnames and provide more versatility than the old form inferred from inventory.
+* Now, using `modification_time` and `access_time` parameters in the `ansible.builtin.file` module, the complete idempotency of the role is duly represented in the tasks results.
+* Proxmoxer is not required for the tasks of this role. The tasks that ensured that this false dependency was installed were removed.
+* Full implementation of `pve_*` namespace usage, consistent with other Proxmox roles.
+* This role configures the Proxmox firewall for both virtual machines and containers. However, many comments, task and variable names referred only to LXC containers. These details have been corrected to reflect the true scope of the role and to avoid confusion.
+* Numerous variables renamed to be mnemonic.
+
 ## [v2.0.0](https://github.com/UdelaRInterior/ansible-role-firewall-proxmox/tree/v2.0.0)
 
-* adopt `pve_*` namespace for `api_host`variables, shared with `udelarinterior.proxmox_create_kvm` and `udelarinterior.proxmox_create_lxc`
-
+* Adopt `pve_*` namespace for `api_host` variables, shared with `udelarinterior.proxmox_create_kvm` and `udelarinterior.proxmox_create_lxc`.
 
 ## [v1.0.0](https://github.com/UdelaRInterior/ansible-role-firewall-proxmox/tree/v1.0.0)
 
-* First stable version. Configures proxmox firewall for containers and VMs
+* First stable version. Configures proxmox firewall for containers and VMs.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ pve_hostname: "{{ inventory_hostname.split('.')[0] }}"
 ## Indicates if the cluster firewall will also be configured.
 ## Keep in mind that modifications to cluster configurations can
 ## affect many hosts, especially if groups are defined. Use with care
-pve_firewall_configure_cluster: true
+pve_firewall_configure_cluster: false
 
 ## Path to go to find firewall files
 pve_firewall_configuration_files: "firewall_proxmox/etc/pve/firewall"

--- a/README.md
+++ b/README.md
@@ -1,107 +1,116 @@
 Ansible Role: firewall_proxmox
 =========
 
-An Ansible role to enable and setting on our cluster instance, virtual machines and containers, the firewall service provided by Proxmox.
+[![Galaxy](https://img.shields.io/badge/galaxy-UdelaRInterior.firewall__proxmox-blue.svg)](https://galaxy.ansible.com/udelarinterior/firewall_proxmox) ![GitHub tag (latest by date)](https://img.shields.io/github/v/tag/udelarinterior/ansible-role-firewall-proxmox?label=release&logo=github&style=social) ![GitHub stars](https://img.shields.io/github/stars/udelarinterior/ansible-role-firewall-proxmox?style=social) ![GitHub forks](https://img.shields.io/github/forks/udelarinterior/ansible-role-firewall-proxmox?style=social)
+
+An Ansible role to enable and setting on our cluster instance, virtual machines and containers, the firewall service provided by Proxmox VE.
 
 We can define through files, the rules that we want to apply to each host independently. In case of running the playbook in a host for which no rules were defined, a set of default rules that enable HTTP, HTTPS, SSH and ping traffic will be established.
 
-[Proxmox Firewall Wiki](https://pve.proxmox.com/wiki/Firewall)
+- [Proxmox Firewall Documentation](https://pve.proxmox.com/wiki/Firewall).
 
 
 Requirements
 ------------
 
-You must act on a Proxmox node or cluster already configured, i.e. you need Proxmox Virtual Environment (PVE) node already installed (tested with PVE 5), and a Proxmox user with LXC/KVM creation rights.
+You must act on a Proxmox Virtual Environment (PVE) node or cluster already configured. i.e. you need a PVE node already installed (tested with PVE 5 and 6) and a Proxmox user with LXC/KVM creation rights.
 
-Yo also need an ssh key configured in the local machine, where ansible is ran, i.e. a file `~/.ssh/id_rsa.pub`.
+Yo also need an SSH key configured in the local machine, where Ansible is ran. i.e. a file `~/.ssh/id_rsa.pub`.
 
-Additionally, note that the firewall must be enabled in the network interface (s) of the host in which you want it to work.
+Additionally, note that the firewall must be enabled in the network interface(s) of the host in which you want it to work.
 
 
 Installation
 ------------
 
+```shell
+$ ansible-galaxy install udelarinterior.firewall_proxmox
+```
+
 To be able to update later and eventually to modify it, prefer using `requirements.yml` with the git source:
 
 ```yaml
-  ### From GitHub
-- name: firewall_proxmox
+- name: udelarinterior.firewall_proxmox
   src: https://github.com/UdelaRInterior/ansible-role-firewall-proxmox.git
-  scm: git
 ```
-
 And then download it with `ansible-galaxy`:
 
 ```shell
-$ ansible-galaxy install -r requirements.yml -g
+$ ansible-galaxy install -r requirements.yml
 ```
 
-Using `git`, you'll have to be carefull to folder name :
+Using `git`, you'll have to be carefull to folder name:
 
 ```shell
-$ git clone https://github.com/UdelaRInterior/ansible-role-firewall-proxmox.git firewall_proxmox
+$ git clone https://github.com/UdelaRInterior/ansible-role-firewall-proxmox.git udelarinterior.firewall_proxmox
 ```
 
 Role Variables
 --------------
 
-The `defaults` variables define our cluster node (pve_api_host) and the location of firewall configuration files. To be specified by host under `files/firewall_proxmox/host_name/host_fqdn.fw`
+The `defaults` variables define our cluster node (`pve_api_host`) and the location of firewall configuration files.
+
+A new interface was introduced in v3.0.0, with role's variables defined in the `pve_*` namespace when they are shared between several Proxmox roles, and in the `pve_firewall_*` namespace when they are specific to the present one.
 
 ```yaml
-## Indicates if the cluster firewall will also be configured.
-## Keep in mind that modifications to cluster configurations can affect many hosts,
-## especially if groups are defined. Use with care
-firewall_proxmox_configure_cluster: true
-
 ## Our Proxmox Virtual Enviroment node
-pve_api_host: my_node.my_cluster.org
+pve_api_host: mynode.mycluster.org
 
-## Route to the lxc container correspondent .fw file. Relative to ansible project 'files' folder.
-project_lxc_firewall_file: "firewall_proxmox/{{ inventory_hostname }}/{{ inventory_hostname.split('.')[0] }}.fw"
+# By default, we suppose that `inventory_hostname` is the FQDN or the hostname of the host to create, so we set the variable to the hostname.
+# You can arbitrarly define this hostname
+pve_hostname: "{{ inventory_hostname.split('.')[0] }}"
 
-## Route to the lxc container correspondent .fw file. Absolute to the file on our local machine that runs the playbook.
-local_path_to_lxc_firewall_file: "{{ playbook_dir }}/files/{{ project_lxc_firewall_file }}"
+## Indicates if the cluster firewall will also be configured.
+## Keep in mind that modifications to cluster configurations can
+## affect many hosts, especially if groups are defined. Use with care
+pve_firewall_configure_cluster: true
+
+## Path to go to find firewall files
+pve_firewall_configuration_files: "firewall_proxmox/etc/pve/firewall"
+
+## Path to the host correspondent .fw file. Relative to Ansible project 'files' folder.
+pve_firewall_host_configuration_file: "{{ pve_firewall_configuration_files }}/{{ pve_hostname }}.fw"
+
+## Path to the host correspondent .fw file. Absolute to the file on our local machine that runs the playbook.
+pve_firewall_path_to_host_configuration_file: "{{ playbook_dir }}/files/{{ pve_firewall_host_configuration_file }}"
 ```
 
 Dependencies
 ------------
 
-We need ansible version >= 2.5 (?) to have the appropriate API of Proxmox modules. (Tested on Ansible 2.7)
-
-Proxmox PVE 5 installed in a cluster node.
-
+We need Ansible version >= 2.10 and a Proxmox Virtual Environment node or cluster version >= 5
 
 Example Playbook
 ----------------
 
 Supposing that:
-* `my_node.my_cluster.org` is our PVE node NS (api on port 8006)
-* `my_node` it's PVE node name
+* `mynode.mycluster.org` is our PVE node NS (API on port 8006)
+* `mynode` it's PVE node name
 * `deploy` our Proxmox user in this node
 * `pve_containers_group` an Ansible group of the containers to define
-* containers are named `<container>.my_node.my_cluster.org`
-* container's firewall file can be found in `<playbook_path>/files/firewall_proxmox/<container>.my_node.my_cluster.org.fw`
+* containers are named `<container>.mynode.mycluster.org`
+* container's firewall file can be found in `<playbook_path>/files/firewall_proxmox/<container>.mynode.mycluster.org.fw`
 
 Then our variables should be defined as follows:
 ```yaml
-pve_api_host: my_node.my_cluster.org
+pve_api_host: mynode.mycluster.org
 
-project_lxc_firewall_file: "firewall_proxmox/{{ inventory_hostname }}.fw"
+pve_firewall_host_configuration_file: "firewall_proxmox/{{ inventory_hostname }}.fw"
 
-local_path_to_lxc_firewall_file: "{{ playbook_dir }}/files/{{ project_lxc_firewall_file }}"
+pve_firewall_path_to_host_configuration_file: "{{ playbook_dir }}/files/{{ pve_firewall_host_configuration_file }}"
 ```
 
 Run the following playbook, enable the firewall for the cluster and configure (based on the .fw files) the desired rules for each host:
+```yaml
+  - name: Enable and configure Proxmox firewall for the containers declared in pve_containers_group
+    hosts: pve_containers_group
+    remote_user: deploy
+    become: yes
+    gather_facts: no
 
-    - name: Enable and configure Proxmox firewall for the containers declared in pve_containers_group
-      hosts: pve_containers_group
-      remote_user: deploy
-      become: yes
-      gather_facts: no
-
-      roles:
-        - firewall_proxmox
-
+    roles:
+      - udelarinterior.firewall_proxmox
+```
 
 License
 -------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,7 @@ pve_hostname: "{{ inventory_hostname.split('.')[0] }}"
 ## Indicates if the cluster firewall will also be configured.
 ## Keep in mind that modifications to cluster configurations can
 ## affect many hosts, especially if groups are defined. Use with care
-pve_firewall_configure_cluster: true
+pve_firewall_configure_cluster: false
 
 ## Path to go to find firewall files
 pve_firewall_configuration_files: "firewall_proxmox/etc/pve/firewall"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,18 +2,24 @@
 # defaults file for pve-firewall
 
 ## Our Proxmox Virtual Enviroment node
-pve_api_host: "{{ api_host if api_host is defined else 'my_node.my_cluster.org' }}"
+pve_api_host: mynode.mycluster.org
+
+# By default, we suppose that `inventory_hostname` is the FQDN or the hostname of the host to create, so we set the variable to the hostname.
+# You can arbitrarly define this hostname
+pve_hostname: "{{ inventory_hostname.split('.')[0] }}"
 
 ## Indicates if the cluster firewall will also be configured.
-## Keep in mind that modifications to cluster configurations can affect many hosts,
-## especially if groups are defined. Use with care
-firewall_proxmox_configure_cluster: true
+## Keep in mind that modifications to cluster configurations can
+## affect many hosts, especially if groups are defined. Use with care
+pve_firewall_configure_cluster: true
 
-## Root of all proxmox firewall config files
-firewall_proxmox_files: "firewall_proxmox/etc/pve/firewall"
+## Path to go to find firewall files
+pve_firewall_configuration_files: "firewall_proxmox/etc/pve/firewall"
 
-## Route to the lxc container correspondent .fw file. Relative to ansible project 'files' folder.
-firewall_proxmox_lxc_file: "{{ firewall_proxmox_files }}/{{ inventory_hostname.split('.')[0] }}.fw"
+## Path to the host correspondent .fw file. Relative to Ansible project 'files' folder.
+pve_firewall_host_configuration_file: "{{ pve_firewall_configuration_files }}/{{ pve_hostname }}.fw"
 
-## Route to the lxc container correspondent .fw file. Absolute to the file on our local machine that runs the playbook.
-local_path_to_lxc_firewall_file: "{{ playbook_dir }}/files/{{ firewall_proxmox_lxc_file }}"
+## Path to the host correspondent .fw file. Absolute to the file on our local machine that runs the playbook.
+pve_firewall_path_to_host_configuration_file: "{{ playbook_dir }}/files/{{ pve_firewall_host_configuration_file }}"
+
+...

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,7 +2,9 @@
 # handlers file for pve-firewall
 
 - name: reload pve-firewall
-  service:
+  ansible.builtin.service:
     name: pve-firewall
     state: reloaded
   delegate_to: "{{ pve_api_host }}"
+
+...

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
 
   license: GPLv3
 
-  min_ansible_version: 2.4
+  min_ansible_version: 2.10
 
   platforms:
     - name: Debian

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,33 +1,11 @@
 ---
 # tasks file for firewall_proxmox
 
-## Obtener fqdn del inventory_hostname
-- name: Get fqdn from inventory_hostname
-  set_fact:
-    proxmox_hostname: "{{ inventory_hostname.split('.')[0] }}"
-
-
-## Verificar si python-pip está instalado en el nodo proxmox
-- name: Verify that python-pip is installed in the proxmox node
-  apt:
-    name: python-pip
-    state: present
-  delegate_to: "{{ pve_api_host }}"
-
-
-## Verificar si el módulo proxmoxer de python está instalado
-- name: Verify if proxmoxer pip module is installed
-  pip:
-    name: proxmoxer
-    state: present
-  delegate_to: "{{ pve_api_host }}"
-
-
 ## Obtener el ID del host
 - name: Get the host ID
-  shell: |
+  ansible.builtin.shell: |
     set -o pipefail
-    { pct list & qm list; } | grep -w {{ proxmox_hostname }} | awk '{ print $1 }'
+    { pct list & qm list; } | grep -w {{ pve_hostname }} | awk '{ print $1 }'
   args:
     executable: /bin/bash
   delegate_to: "{{ pve_api_host }}"
@@ -36,7 +14,7 @@
 
 ## Asegurar existencia del directorio de configuración de firewall para el CLUSTER
 - name: Ensure the existence of the firewall configuration directory for the CLUSTER
-  file:
+  ansible.builtin.file:
     path: "/etc/pve/firewall"
     state: directory
     owner: root
@@ -46,19 +24,21 @@
 
 ## Asegurar existencia del archivo de configuración de firewall para el CLUSTER
 - name: Ensure the existence of the firewall configuration file for the CLUSTER
-  file:
+  ansible.builtin.file:
     path: "/etc/pve/firewall/cluster.fw"
     state: touch
     owner: root
     group: www-data
     mode: "0640"
+    modification_time: preserve
+    access_time: preserve
   delegate_to: "{{ pve_api_host }}"
-  when: firewall_proxmox_configure_cluster | bool
+  when: pve_firewall_configure_cluster | bool
 
 ## Copiar archivo de configuración de firewall para el CLUSTER (Llamado "Datacenter" en panel web de Proxmox)
 - name: Copy firewall configuration file for the CLUSTER (Called "Datacenter" in Proxmox web panel)
-  copy:
-    src: "{{ firewall_proxmox_files }}/cluster.fw"
+  ansible.builtin.copy:
+    src: "{{ pve_firewall_configuration_files }}/cluster.fw"
     dest: "/etc/pve/firewall/cluster.fw"
     owner: root
     group: www-data
@@ -66,32 +46,32 @@
   notify:
     - reload pve-firewall
   delegate_to: "{{ pve_api_host }}"
-  when: firewall_proxmox_configure_cluster | bool
+  when: pve_firewall_configure_cluster | bool
 
-
-## Comprobar si existe un archivo de firewall definido para el contenedor en nuestro proyecto
-- name: Check if there is a firewall file defined for the container/vm in our project
-  stat:
-    path: "{{ local_path_to_lxc_firewall_file }}"
+## Comprobar si existe un archivo de firewall definido para el contenedor/VM en nuestro proyecto
+- name: Check if there is a firewall file defined for the container/VM in our project
+  ansible.builtin.stat:
+    path: "{{ pve_firewall_path_to_host_configuration_file }}"
   become: no
   delegate_to: localhost
-  register: host_firewall_file
+  register: host_firewall_configuration_file
 
-
-## Asegurar existencia del archivo de configuración de firewall para el contenedor
-- name: Ensure existence of the firewall configuration file for the container/vm
-  file:
+## Asegurar existencia del archivo de configuración de firewall para el contenedor/VM
+- name: Ensure existence of the firewall configuration file for the container/VM
+  ansible.builtin.file:
     path: "/etc/pve/firewall/{{ VMID.stdout }}.fw"
     state: touch
     owner: root
     group: www-data
     mode: "0640"
+    modification_time: preserve
+    access_time: preserve
   delegate_to: "{{ pve_api_host }}"
 
-## Set archivo de configuración de firewall para el contenedor si está definido
-- name: Set firewall configuration file for the container/vm if it is defined
-  copy:
-    src: "{{ firewall_proxmox_lxc_file }}"
+## Copiar archivo de configuración de firewall para el contenedor/VM si está definido
+- name: Copy firewall configuration file for the container/VM if it is defined
+  ansible.builtin.copy:
+    src: "{{ pve_firewall_host_configuration_file }}"
     dest: "/etc/pve/firewall/{{ VMID.stdout }}.fw"
     owner: root
     group: www-data
@@ -99,12 +79,12 @@
   notify:
     - reload pve-firewall
   delegate_to: "{{ pve_api_host }}"
-  when: host_firewall_file.stat.exists
+  when: host_firewall_configuration_file.stat.exists
 
-## Set archivo por defecto de firewall para el contenedor sin definición
-- name: Set default firewall file for the container/vm without definition
-  copy:
-    src: "{{ firewall_proxmox_files }}/default.fw"
+## Copiar archivo por defecto de firewall para el contenedor/VM sin definición
+- name: Copy default firewall file for the container/VM without definition
+  ansible.builtin.copy:
+    src: "{{ pve_firewall_configuration_files }}/default.fw"
     dest: "/etc/pve/firewall/{{ VMID.stdout }}.fw"
     owner: root
     group: www-data
@@ -112,4 +92,6 @@
   notify:
     - reload pve-firewall
   delegate_to: "{{ pve_api_host }}"
-  when: (not host_firewall_file.stat.exists)
+  when: (not host_firewall_configuration_file.stat.exists)
+
+...

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -3,3 +3,5 @@
   remote_user: root
   roles:
     - firewall_proxmox
+
+...

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,4 @@
 ---
 # vars file for pve-firewall
+
+...


### PR DESCRIPTION
In this branch I add numerous improvements and updates to the role to adapt it to the new use of collections (FQCN) since Ansible v2.10. As stated in the CHANGELOG, the changes that involve the release of a new major version (v3.0.0) include:
* The variable `pve_hostname` is now available to use custom hostnames and provide more versatility than the old form inferred from inventory.
* Now, using `modification_time` and `access_time` parameters in the `ansible.builtin.file` module, the complete idempotency of the role is duly represented in the tasks results.
* Proxmoxer is not required for the tasks of this role. The tasks that ensured that this false dependency was installed were removed.
* Full implementation of `pve_*` namespace usage, consistent with other Proxmox roles.
* This role configures the Proxmox firewall for both virtual machines and containers. However, many comments, task and variable names referred only to LXC containers. These details have been corrected to reflect the true scope of the role and to avoid confusion.
* Numerous variables renamed to be mnemonic.